### PR TITLE
cmake: add versioned CMake package config support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,22 @@ project(zerocode
   DESCRIPTION "A C++ project with no code"
   LANGUAGES CXX
 )
-include(CTest)
+
+option(ZEROCODE_ENABLE_WARNINGS "Enable compiler warnings" ON)
+option(ZEROCODE_BUILD_TESTS "Build tests" OFF)
+
+if(ZEROCODE_ENABLE_WARNINGS)
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    add_compile_options(-Wall -Wextra -Wpedantic)
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    add_compile_options(/W4)
+  endif()
+endif()
 
 add_subdirectory(src/zerocode)
-add_subdirectory(test/zerocode)
+
+if(ZEROCODE_BUILD_TESTS)
+  include(CTest)
+  enable_testing()
+  add_subdirectory(test/zerocode)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,22 +7,35 @@ project(zerocode
   DESCRIPTION "A C++ project with no code"
   LANGUAGES CXX
 )
-
-option(ZEROCODE_ENABLE_WARNINGS "Enable compiler warnings" ON)
-option(ZEROCODE_BUILD_TESTS "Build tests" OFF)
-
-if(ZEROCODE_ENABLE_WARNINGS)
-  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-    add_compile_options(-Wall -Wextra -Wpedantic)
-  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    add_compile_options(/W4)
-  endif()
-endif()
+include(CTest)
 
 add_subdirectory(src/zerocode)
+add_subdirectory(test/zerocode)
 
-if(ZEROCODE_BUILD_TESTS)
-  include(CTest)
-  enable_testing()
-  add_subdirectory(test/zerocode)
-endif()
+include(CMakePackageConfigHelpers)
+
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/zerocode-config-version.cmake"
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion
+)
+
+configure_package_config_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/zerocode-config.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/zerocode-config.cmake"
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/zerocode
+)
+
+install(FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/zerocode-config.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/zerocode-config-version.cmake"
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/zerocode
+  COMPONENT libzerocode-dev
+)
+
+install(EXPORT zerocode
+  FILE zerocodeTargets.cmake
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/zerocode"
+  COMPONENT libzerocode-dev
+  NAMESPACE zerocode::
+)

--- a/cmake/zerocode-config.cmake.in
+++ b/cmake/zerocode-config.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/zerocodeTargets.cmake")


### PR DESCRIPTION
This PR enhances `zerocode`'s CMake packaging by enabling modern `find_package()` support:

- Added `zerocode-config-version.cmake` for version-aware lookups
- Introduced `zerocode-config.cmake` generated via `configure_package_config_file`
- Installed `zerocodeTargets.cmake` to expose the `zerocode::zerocode` target to downstream users

All install locations and components match the existing `libzerocode-dev` layout. This allows downstream consumers to use:

```cmake
find_package(zerocode 1.0 REQUIRED)
target_link_libraries(my_app PRIVATE zerocode::zerocode)
