### PR TITLE
Add Conan recipe with test_package support

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,49 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
+
+class ZerocodeConan(ConanFile):
+    name = "zerocode"
+    version = "1.0.0"
+    license = "MIT"
+    author = "Bret Brown"
+    url = "https://github.com/bretbrownjr/zerocode"
+    description = "A C++ project with no code"
+    topics = ("cmake", "library", "packaging")
+    
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False]
+    }
+    default_options = {
+        "shared": False
+    }
+
+    exports_sources = "*"
+    package_type = "library"
+    
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "zerocode")
+        self.cpp_info.set_property("cmake_target_name", "zerocode::zerocode")
+
+        # Manually tell Conan the expected library name
+        config = str(self.settings.build_type).lower()
+        self.cpp_info.libs = [f"zerocode.{config}"]
+

--- a/src/zerocode/zerocode.hxx
+++ b/src/zerocode/zerocode.hxx
@@ -1,2 +1,4 @@
 // Copyright © 2024 Bret Brown
 // SPDX-License-Identifier: MIT
+#pragma once
+inline void hello_zerocode() {}

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package CXX)
+
+find_package(zerocode REQUIRED)
+
+add_executable(test_package main.cpp)
+target_link_libraries(test_package PRIVATE zerocode::zerocode)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,0 +1,27 @@
+from conan import ConanFile
+from conan.tools.cmake import cmake_layout, CMakeToolchain, CMakeDeps, CMake
+
+class ZerocodeTestConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        self.run("./test_package", env="conanrun")

--- a/test_package/main.cpp
+++ b/test_package/main.cpp
@@ -1,0 +1,6 @@
+#include <zerocode.hxx>
+
+int main() {
+    hello_zerocode(); // or any no-op usage
+    return 0;
+}


### PR DESCRIPTION
This PR adds full Conan packaging support for the `zerocode` C++ library, including a test package for validation.

### Features:
- `conanfile.py` builds `zerocode` using its native CMake system
- Supports `shared` option (default: False)
- Automatically picks up the build variant library (e.g. `libzerocode.debug.a`)
- Exposes `zerocode::zerocode` target for downstream `find_package()` use

### Includes:
- `test_package/` folder with:
  - Minimal `main.cpp` that includes and links to `zerocode`
  - CMake-based test project
  - Conan validation via `self.tested_reference_str`

### Usage:
In a Conan consumer project:

```ini
[requires]
zerocode/1.0.0

[generators]
CMakeDeps
CMakeToolchain
```
And in `CMakeLists.txt`:
```
find_package(zerocode REQUIRED)
target_link_libraries(my_app PRIVATE zerocode::zerocode)
```
This allows seamless use of zerocode in Conan-based C++ builds and prepares for future submission to Conan Center Index (CCI).