### PR TITLE
Add GitHub Actions matrix CI for CMake build and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-matrix:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        build_type: [Debug, Release]
+        compiler: [gcc, clang]
+
+    env:
+      CC: ${{ matrix.compiler }}
+      CXX: ${{ matrix.compiler }}++
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y build-essential cmake ninja-build
+
+      - name: Configure with CMake
+        run: >
+          cmake -B build
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          -G Ninja
+          -DCMAKE_C_COMPILER=${{ env.CC }}
+          -DCMAKE_CXX_COMPILER=${{ env.CXX }}
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Run CTest
+        run: ctest --test-dir build --output-on-failure


### PR DESCRIPTION
This PR introduces GitHub Actions-based CI that validates `zerocode` across compilers and build types using native CMake and CTest.

### Matrix Configuration:
- Compilers: `gcc`, `clang`
- Build types: `Debug`, `Release`

### Each job performs:
- `cmake` configuration using Ninja generator
- `cmake --build` to compile the project
- `ctest` to execute all test cases from `test/zerocode`

This matrix CI ensures all supported configurations are continuously tested and helps maintain reliability across environments.
